### PR TITLE
build: revert config change for actions/checkout@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name }}
 
       # Do a dry run of PSR
       - name: Test release


### PR DESCRIPTION
This reverts a change in the CI configuration for [actions/checkout@v4](https://github.com/chemelli74/aiocomelit/pull/81/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR84) that slipped in during #81 