### PR TITLE
fix: revert strict login check

### DIFF
--- a/src/aiocomelit/api.py
+++ b/src/aiocomelit/api.py
@@ -210,7 +210,7 @@ class ComelitCommonApi:
         cookies = await self._post_page_result("/login.cgi", payload)
         _LOGGER.debug("[%s] Cookies: %s", self._logging, cookies)
 
-        if not cookies or not await self._check_logged_in(host_type):
+        if not cookies:
             _LOGGER.warning(
                 "[%s] Authentication failed: no cookies received", self._logging
             )


### PR DESCRIPTION
Revert #330

Some older devices cannot handle two login so close together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication flow to better handle existing session cookies, reducing intermittent login failures.
  * Enhanced error handling with clearer feedback when required cookies are missing, preventing confusing authentication states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->