### PR TITLE
test: allow to skip VEDO login in library_test.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ The script accept command line arguments or a library_test.json config file:
 
 ```json
 {
+  "bridge_skip": false,
   "bridge": "192.168.1.252",
   "bridge_port": 80,
   "bridge_pin": 12345,
   "bridge_vedo": false,
+  "vedo_skip": false,
   "vedo": "192.168.1.230",
   "vedo_port": 8080,
   "vedo_pin": 67890,

--- a/library_test.py
+++ b/library_test.py
@@ -69,7 +69,7 @@ def get_arguments() -> tuple[ArgumentParser, Namespace]:
         "--bridge_skip",
         "-bs",
         action="store_true",
-        help="Skip Serial bridge tests",
+        help="Skip Serial bridge login",
     )
     parser.add_argument(
         "--vedo",
@@ -91,6 +91,12 @@ def get_arguments() -> tuple[ArgumentParser, Namespace]:
         type=str,
         default="",
         help="Set VEDO system pin",
+    )
+    parser.add_argument(
+        "--vedo_skip",
+        "-vs",
+        action="store_true",
+        help="Skip VEDO system login",
     )
     parser.add_argument(
         "--test",
@@ -265,12 +271,15 @@ async def main() -> None:
     session = ClientSession(cookie_jar=jar, connector=connector)
 
     if args.bridge_skip:
+        print(f"{BRIDGE}: Skipping login as requested")
         bridge_vedo_enabled = False
     else:
         bridge_vedo_enabled = await bridge_test(session, args)
 
+    if args.vedo_skip:
+        print(f"{VEDO}: Skipping login as requested")
     # VEDO is not accessible via Serial bridge, need direct access
-    if not bridge_vedo_enabled:
+    elif not bridge_vedo_enabled:
         # VEDO system mandatorily requires a pin for direct access
         if not args.vedo_pin:
             print(f"{VEDO}: Missing PIN. Skipping tests")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation to include new `bridge_skip` and `vedo_skip` boolean settings for controlling login behavior.

* **New Features**
  * Added `--vedo_skip` CLI flag to allow users to skip VEDO system login during initialization.

* **Bug Fixes**
  * Clarified `--bridge_skip` flag help text to accurately describe its function of skipping serial bridge login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->